### PR TITLE
fixing deprecation warnings

### DIFF
--- a/tasks/crx.js
+++ b/tasks/crx.js
@@ -40,10 +40,10 @@ function configure(defaults){
   grunt.utils._.defaults(self.data, defaults);
 
   // Checking availability
-  if (!path.existsSync(self.file.src)){
+  if (!fs.existsSync(self.file.src)){
     throw self.taskError('Unable to locate source directory.');
   }
-  if (!path.existsSync(self.data.privateKey)){
+  if (!fs.existsSync(self.data.privateKey)){
     throw self.taskError('Unable to locate your private key.');
   }
 


### PR DESCRIPTION
Saw the following warning: 
path.existsSync is now called `fs.existsSync`.

...and made the suggested change.
