### PR TITLE
Fix buildXML() call for extension w/o update_url

### DIFF
--- a/lib/autoupdate.js
+++ b/lib/autoupdate.js
@@ -19,6 +19,7 @@ exports.init = function(grunt){
   function buildXML(ChromeExtension, callback) {
     if (!ChromeExtension.manifest.update_url || !ChromeExtension.codebase){
       callback();
+      return;
     }
 
     ChromeExtension.generateUpdateXML();


### PR DESCRIPTION
`ChromeExtension.generateUpdateXML();` must not be called if extension has no `update_url` field in manifest.
