### PR TITLE
`config.rootDirectory` should be a String, not Array

### DIFF
--- a/lib/crx.js
+++ b/lib/crx.js
@@ -145,7 +145,8 @@ exports.init = function(grunt){
     }
 
     // @todo remove that to better separate grunt config and Chrome Extension config
-    config.rootDirectory = config.src;
+    // rootDirectory should be a String, not Array
+    config.rootDirectory = sourceDir;
     config.maxBuffer = config.options.maxBuffer || config.maxBuffer || undefined;
 
     return config;


### PR DESCRIPTION
My `Gruntfile.coffee`:

```
   ...
    crx:
      dev:
        src: 'out/lib/'
        dest: 'out/'
   ...
```

I have got an exception:

```
 % grunt --stack crx
Running "crx:dev" (crx) task
Fatal error: path must be a string
TypeError: path must be a string
    at Object.fs.stat (fs.js:670:11)
    at /home/../grunt-crx/node_modules/crx/node_modules/wrench/lib/wrench.js:339:12
    at Object.oncomplete (fs.js:107:15)
```
