### PR TITLE
`grunt.task` has no `taskError` property

### DIFF
--- a/lib/crx.js
+++ b/lib/crx.js
@@ -58,7 +58,7 @@ exports.init = function(grunt){
       function(done){
         ChromeExtension.pack(function(err, data){
           if (err){
-            throw new grunt.task.taskError(err);
+            grunt.fail.fatal(err);
           }
 
           grunt.file.write(this.dest, data);


### PR DESCRIPTION
I have got another error:

```
$ grunt --stack crx
Running "crx:dev" (crx) task
Fatal error: undefined is not a function
TypeError: undefined is not a function
    at .../node_modules/grunt-crx/lib/crx.js:61:19
    at null.<anonymous> (.../node_modules/grunt-crx/node_modules/crx/src/crx.js:39:27)
    at null.<anonymous> (.../node_modules/grunt-crx/node_modules/crx/src/crx.js:112:26)
    at ChildProcess.exithandler (child_process.js:641:7)
    at ChildProcess.EventEmitter.emit (events.js:98:17)
    at maybeClose (child_process.js:735:16)
    at Socket.<anonymous> (child_process.js:948:11)
    at Socket.EventEmitter.emit (events.js:95:17)
    at Pipe.close (net.js:466:12)
```

You could get mime:
1. remove your 'zip' command
2. `git clone https://github.com/pismute/ladybucks.git`
3. `cd ladybucks;npm install`
4. `grunt --stack`

`grunt.task` has no `taskError` function. I think we can use this function in test only. I am not sure this problem, but It works.

ps> I have an another question. I have got this error if I installed grunt-crx from npm repository. but I cannot get error if I install from local disk using 'npm link grunt-crx'. I cannot understand why...

Thank you.
