### PR TITLE
Only delete existent files

### DIFF
--- a/lib/crx.js
+++ b/lib/crx.js
@@ -54,7 +54,9 @@ exports.init = function(grunt){
 
         // deletes all the file in parallel
         grunt.util.async.forEach(files, function(filepath, done){
-          grunt.file.delete(filepath, {force: true});
+          if (grunt.file.exists(filepath)) {
+            grunt.file.delete(filepath, {force: true});
+          }
 
           done();
         }, next);


### PR DESCRIPTION
When specified exludes with globs, such as `moment/locale/**` for example, the directory gets deleted first, hence following files supposed to be deleted don't exist any more, which results in the following errors:

``` console
Deleting tmp/crx-2y3bcped4na/bower_components/moment/locale...OK
Deleting tmp/crx-2y3bcped4na/bower_components/moment/locale/af.js...ERROR
>> Cannot delete nonexistent file.
Deleting tmp/crx-2y3bcped4na/bower_components/moment/locale/ar-ma.js...ERROR
>> Cannot delete nonexistent file.
Deleting tmp/crx-2y3bcped4na/bower_components/moment/locale/ar-sa.js...ERROR
```

This pull request adss a check if the file exists before running the delete operation on it.
