### PR TITLE
Fix options not being passed to taskConfig

### DIFF
--- a/lib/crx.js
+++ b/lib/crx.js
@@ -135,7 +135,7 @@ exports.init = function(grunt){
     taskConfig.options.privateKey = resolveHomeDirectory(taskConfig.options.privateKey);
 
     if (!grunt.file.exists(taskConfig.options.privateKey)){
-      grunt.fail.fatal('Unable to locate your private key.');
+      grunt.fail.fatal('Unable to locate your private key at path "' + taskConfig.options.privateKey + '".');
     }
     else{
       crxConfig.privateKey = grunt.file.read(taskConfig.options.privateKey);

--- a/tasks/crx.js
+++ b/tasks/crx.js
@@ -9,6 +9,7 @@
 "use strict";
 
 var async = require('async');
+var _ = require('lodash');
 
 module.exports = function(grunt) {
   var extensionHelper = require('./../lib/crx').init(grunt);
@@ -20,7 +21,11 @@ module.exports = function(grunt) {
 
     this.requiresConfig('crx');
 
+    var options = this.data.options;
     this.files.forEach(function(taskConfig) {
+      if (options) {
+        taskConfig.options = _.extend(options, taskConfig.options || {});
+      }
       var extension = extensionHelper.createObject(taskConfig, defaults);
 
       // Building

--- a/test/lib-crx.js
+++ b/test/lib-crx.js
@@ -93,4 +93,22 @@ describe('lib/crx', function(){
       done();
     });
   });
+
+  it('should work with a real-world grunt-crx run', function (done) {
+
+    // load the task as if done by grunt
+    var task = require('../tasks/crx.js');
+    task(grunt);
+
+    grunt.option('options.silently', true);
+
+    // run it as if done by grunt (just no log output)
+    grunt.log.muted = true;
+    grunt.tasks(['crx:standard'], {}, function() {
+      expect(grunt.file.expand('test/data/files/test.crx')).to.have.lengthOf(1);
+      grunt.log.muted = false;
+      done();
+    });
+
+  });
 });


### PR DESCRIPTION
When using the task with a non-standard key location, the options never were passed to the task config, as the options were removed due to multiTask files normalization, resulting in an error
```console
Fatal error: Unable to locate your private key.
```
if one changed the `options.privateKey` property.
This was never found out, because the tests itself use the internal method `extensionHelper.createObject` and passed the `options` in. The code in `tasks/crx.js` was never part of the tests.

This PR fixes this, by properly passing on the `options` hash to the taskConfig if defined. As a side-effect it also adds coverage for `tasks/crx.js`.