### PR TITLE
Depend on crx@3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "crx": "^2.0.0",
+    "crx": "^3.0.1",
     "lodash": "^2.4.1",
     "rimraf": "^2.2.8",
     "mkdirp": "^0.5.0"


### PR DESCRIPTION
I'd like to use `grunt-crx` with `crx@3.x`. It probably needs to bump version to 2.x when publish it.