### PR TITLE
Updated readme to indicate npm latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Then add this line to your project's `Gruntfile.js`:
 grunt.loadNpmTasks('grunt-crx');
 ```
 
+Note: v0.3.4 has been tagged as the latest version to avoid security issues in packaged extensions. See [issue #44](https://github.com/oncletom/grunt-crx/issues/44). If you want to use the most recent version which corresponds to the following documentation, you can install it specifically: 
+
+```bash
+npm install --save-dev grunt-crx@1.0.3
+```
+
 ## Documentation
 
 This task is a [multi task](http://gruntjs.com/creating-tasks#multi-tasks), meaning that grunt will automatically iterate over all `crx` targets if a target is not specified.


### PR DESCRIPTION
Based on our conversation in [issue #61](https://github.com/oncletom/grunt-crx/issues/61), I think this change would make it easier for users to figure out how to use the project within the context of npm.