### PR TITLE
upgrade the crx version to ^5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "crx": "^3.0.1",
+    "crx": "^5.0.0",
     "es6-promise": "^3.0.0",
     "mkdirp": "^0.5.0",
     "os-homedir": "^1.0.1",


### PR DESCRIPTION
CRX2 will not be supported any more starting from Chrome 77
https://chromium.googlesource.com/chromium/src/+/372cd96a5d591af941051ab04b3dfee946b92912
